### PR TITLE
#140648415 Present deactivated users

### DIFF
--- a/wger/core/views/user.py
+++ b/wger/core/views/user.py
@@ -526,6 +526,7 @@ class UserListView(LoginRequiredMixin, PermissionRequiredMixin, ListView):
                                           _('Username'),
                                           _('Name'),
                                           _('Last activity'),
-                                          _('Gym')],
+                                          _('Gym'),
+                                          _('Status')],
                                  'users': context['object_list']['members']}
         return context

--- a/wger/gym/templates/gym/partial_user_list.html
+++ b/wger/gym/templates/gym/partial_user_list.html
@@ -47,6 +47,13 @@ $(document).ready( function () {
             -/-
         {% endif %}
     </td>
+    <td>
+        {% if current_user.obj.is_active %}
+            <span class="label label-success">Active</span
+        {% else %}
+            <span class="label label-danger">Inactive</span>
+        {% endif %}
+    </td>
     {% endif %}
 </tr>
 {% endfor %}


### PR DESCRIPTION
**What does this PR do?**

Creates an extra column in the user list table. The column holds colored labels that specify the status of a user. 

<img width="924" alt="screen shot 2017-03-07 at 15 57 07" src="https://cloud.githubusercontent.com/assets/24287486/23657388/e5be3e4c-034e-11e7-9d4d-92ef3a4d0c42.png">


**What are the relevant pivotal tracker stories?**
#140648415